### PR TITLE
Fix resolution of references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
-      <version>1.2.0</version>
+      <version>1.4.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/github/okapies/hoc2js/Hoc2Js.java
+++ b/src/main/java/com/github/okapies/hoc2js/Hoc2Js.java
@@ -30,6 +30,7 @@ public class Hoc2Js {
 
         // resolve
         ConfigResolveOptions resolveOpts = loadResolveOpts(config);
+        obj = obj.resolve(resolveOpts.setAllowUnresolved(true));
         obj = obj.resolveWith(config, resolveOpts);
 
         // render


### PR DESCRIPTION
Resolve failed with the following exception when using references:
`Exception in thread "main" com.typesafe.config.ConfigException$BugOrBroken: replace in parent not possible`
or
`Exception in thread "main" com.typesafe.config.ConfigException$UnresolvedSubstitution: Reader: 2: Could not resolve substitution to a value: ${a}`

The docs for resolveWith says:
> Note that this method does NOT look in this instance for substitution values.

Which means we can't refer to variabled in the same config.
It also says:
> If you want to do that, you could either merge this instance into
> your value source using Config.withFallback,  or you could resolve
> multiple times with multiple sources (using setAllowUnresolved).

I tried using `withFallback`, but the same error still occurred.
This might be due to a bug in typesafe config: lightbend/config#332 https://github.com/lightbend/config/issues/499

This works around that by resolving multiple times as suggested
in the javadoc.

Fixes #1 